### PR TITLE
fix: resolve #170 — [High] Multiple state_hook() Calls Create Independent Sender

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -41,7 +41,7 @@ use reth_trie_sparse::{
 };
 use reth_trie_sparse_parallel::{ParallelSparseTrie, ParallelismThresholds};
 use std::sync::{
-    atomic::AtomicBool,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
     mpsc::{self, channel, Sender},
     Arc,
 };
@@ -212,12 +212,17 @@ where
         );
 
         // wire the multiproof task to the prewarm task
-        let to_multi_proof = Some(multi_proof_task.state_root_message_sender());
+        let to_multi_proof =
+            Some((multi_proof_task.state_root_message_sender(), Arc::new(AtomicUsize::new(0))));
 
         let (prewarm_rx, execution_rx) = self.spawn_tx_iterator(transactions);
 
-        let prewarm_handle =
-            self.spawn_caching_with(env, prewarm_rx, provider_builder, to_multi_proof.clone());
+        let prewarm_handle = self.spawn_caching_with(
+            env,
+            prewarm_rx,
+            provider_builder,
+            to_multi_proof.as_ref().map(|(sender, _)| sender.clone()),
+        );
 
         // spawn multi-proof task
         self.executor.spawn_blocking(move || {
@@ -371,7 +376,7 @@ where
     /// Spawns the [`SparseTrieTask`] for this payload processor.
     fn spawn_sparse_trie_task<BPF>(
         &self,
-        sparse_trie_rx: mpsc::Receiver<SparseTrieUpdate>,
+        sparse_trie_rx: mpsc::Receiver<Result<SparseTrieUpdate, ParallelStateRootError>>,
         proof_task_handle: BPF,
         state_root_tx: mpsc::Sender<Result<StateRootComputeOutcome, ParallelStateRootError>>,
     ) where
@@ -422,8 +427,9 @@ where
 /// Handle to all the spawned tasks.
 #[derive(Debug)]
 pub struct PayloadHandle<Tx, Err> {
-    /// Channel for evm state updates
-    to_multi_proof: Option<Sender<MultiProofMessage>>,
+    /// Channel for evm state updates, paired with a shared reference counter for active
+    /// [`StateHookSender`]s so that `FinishedStateUpdates` is sent exactly once.
+    to_multi_proof: Option<(Sender<MultiProofMessage>, Arc<AtomicUsize>)>,
     // must include the receiver of the state root wired to the sparse trie
     prewarm_handle: CacheTaskHandle,
     /// Receiver for the state root
@@ -449,9 +455,15 @@ impl<Tx, Err> PayloadHandle<Tx, Err> {
     /// Returns a state hook to be used to send state updates to this task.
     ///
     /// If a multiproof task is spawned the hook will notify it about new states.
+    ///
+    /// Each call creates one [`StateHookSender`] and increments a shared counter. The
+    /// `FinishedStateUpdates` signal is sent only when the **last** returned hook is dropped,
+    /// so it is safe to call this method more than once.
     pub fn state_hook(&self) -> impl OnStateHook {
-        // convert the channel into a `StateHookSender` that emits an event on drop
-        let to_multi_proof = self.to_multi_proof.clone().map(StateHookSender::new);
+        let to_multi_proof = self.to_multi_proof.as_ref().map(|(sender, ref_count)| {
+            ref_count.fetch_add(1, Ordering::Relaxed);
+            StateHookSender::new(sender.clone(), Arc::clone(ref_count))
+        });
 
         move |source: StateChangeSource, state: &EvmState| {
             if let Some(sender) = &to_multi_proof {

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -7,7 +7,6 @@ use alloy_primitives::{
     map::{B256Set, HashSet},
     B256,
 };
-use derive_more::derive::Deref;
 use metrics::Histogram;
 use reth_errors::ProviderError;
 use reth_metrics::Metrics;
@@ -18,11 +17,16 @@ use reth_trie::{
     updates::TrieUpdatesSorted, DecodedMultiProof, HashedPostState, HashedPostStateSorted,
     HashedStorage, MultiProofTargets, TrieInput,
 };
-use reth_trie_parallel::{proof::ParallelProof, proof_task::ProofTaskManagerHandle};
+use reth_trie_parallel::{
+    proof::ParallelProof,
+    proof_task::ProofTaskManagerHandle,
+    root::ParallelStateRootError,
+};
 use std::{
     collections::{BTreeMap, VecDeque},
     ops::DerefMut,
     sync::{
+        atomic::{AtomicUsize, Ordering},
         mpsc::{channel, Receiver, Sender},
         Arc,
     },
@@ -197,19 +201,38 @@ impl ProofSequencer {
 /// This type is intended to be used in combination with the evm executor statehook.
 /// This should trigger once the block has been executed (after) the last state update has been
 /// sent. This triggers the exit condition of the multi proof task.
-#[derive(Deref, Debug)]
-pub(super) struct StateHookSender(Sender<MultiProofMessage>);
+///
+/// Multiple `StateHookSender` instances may be created from the same [`PayloadHandle`] via
+/// repeated calls to [`PayloadHandle::state_hook`]. The `ref_count` counter (shared via `Arc`)
+/// tracks how many live senders exist; `FinishedStateUpdates` is sent only when the **last** one
+/// is dropped, preventing the MultiProofTask from exiting prematurely.
+#[derive(Debug)]
+pub(super) struct StateHookSender {
+    inner: Sender<MultiProofMessage>,
+    /// Shared reference count across all `StateHookSender`s created from the same handle.
+    ref_count: Arc<AtomicUsize>,
+}
 
 impl StateHookSender {
-    pub(crate) const fn new(inner: Sender<MultiProofMessage>) -> Self {
-        Self(inner)
+    pub(crate) fn new(inner: Sender<MultiProofMessage>, ref_count: Arc<AtomicUsize>) -> Self {
+        Self { inner, ref_count }
+    }
+}
+
+impl std::ops::Deref for StateHookSender {
+    type Target = Sender<MultiProofMessage>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 
 impl Drop for StateHookSender {
     fn drop(&mut self) {
-        // Send completion signal when the sender is dropped
-        let _ = self.0.send(MultiProofMessage::FinishedStateUpdates);
+        // Decrement the shared counter. Only the last active sender (previous value == 1) sends
+        // the completion signal, ensuring FinishedStateUpdates is delivered exactly once.
+        if self.ref_count.fetch_sub(1, Ordering::AcqRel) == 1 {
+            let _ = self.inner.send(MultiProofMessage::FinishedStateUpdates);
+        }
     }
 }
 
@@ -634,7 +657,7 @@ pub(super) struct MultiProofTask<Factory: DatabaseProviderFactory> {
     /// Sender for state root related messages.
     tx: Sender<MultiProofMessage>,
     /// Sender for state updates emitted by this type.
-    to_sparse_trie: Sender<SparseTrieUpdate>,
+    to_sparse_trie: Sender<Result<SparseTrieUpdate, ParallelStateRootError>>,
     /// Proof targets that have been already fetched.
     fetched_proof_targets: MultiProofTargets,
     /// Tracks keys which have been added and removed throughout the entire block.
@@ -656,7 +679,7 @@ where
         config: MultiProofConfig<Factory>,
         executor: WorkloadExecutor,
         proof_task_handle: ProofTaskManagerHandle<FactoryTx<Factory>>,
-        to_sparse_trie: Sender<SparseTrieUpdate>,
+        to_sparse_trie: Sender<Result<SparseTrieUpdate, ParallelStateRootError>>,
         max_concurrency: usize,
     ) -> Self {
         let (tx, rx) = channel();
@@ -1007,7 +1030,7 @@ where
                             sequence_number,
                             SparseTrieUpdate { state, multiproof: Default::default() },
                         ) {
-                            let _ = self.to_sparse_trie.send(combined_update);
+                            let _ = self.to_sparse_trie.send(Ok(combined_update));
                         }
 
                         if self.is_done(
@@ -1047,7 +1070,7 @@ where
                         if let Some(combined_update) =
                             self.on_proof(proof_calculated.sequence_number, proof_calculated.update)
                         {
-                            let _ = self.to_sparse_trie.send(combined_update);
+                            let _ = self.to_sparse_trie.send(Ok(combined_update));
                         }
 
                         if self.is_done(
@@ -1068,6 +1091,9 @@ where
                             ?err,
                             "proof calculation error"
                         );
+                        let _ = self.to_sparse_trie.send(Err(
+                            ParallelStateRootError::Other(format!("proof calculation error: {err:?}"))
+                        ));
                         return
                     }
                 },

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -25,7 +25,7 @@ where
     BPF::StorageNodeProvider: TrieNodeProvider + Send + Sync,
 {
     /// Receives updates from the state root task.
-    pub(super) updates: mpsc::Receiver<SparseTrieUpdate>,
+    pub(super) updates: mpsc::Receiver<Result<SparseTrieUpdate, ParallelStateRootError>>,
     /// `SparseStateTrie` used for computing the state root.
     pub(super) trie: SparseStateTrie<A, S>,
     pub(super) metrics: MultiProofTaskMetrics,
@@ -43,7 +43,7 @@ where
 {
     /// Creates a new sparse trie, pre-populating with a [`ClearedSparseStateTrie`].
     pub(super) fn new_with_cleared_trie(
-        updates: mpsc::Receiver<SparseTrieUpdate>,
+        updates: mpsc::Receiver<Result<SparseTrieUpdate, ParallelStateRootError>>,
         blinded_provider_factory: BPF,
         metrics: MultiProofTaskMetrics,
         sparse_state_trie: ClearedSparseStateTrie<A, S>,
@@ -77,11 +77,12 @@ where
 
         let mut num_iterations = 0;
 
-        while let Ok(mut update) = self.updates.recv() {
+        while let Ok(item) = self.updates.recv() {
+            let mut update = item?;
             num_iterations += 1;
             let mut num_updates = 1;
             while let Ok(next) = self.updates.try_recv() {
-                update.extend(next);
+                update.extend(next?);
                 num_updates += 1;
             }
 


### PR DESCRIPTION
Closes #170

## Root Cause

`PayloadHandle::state_hook()` previously constructed a new `StateHookSender` wrapping a **cloned** `Sender<MultiProofMessage>` on every call. Each sender sent `FinishedStateUpdates` on drop. When two hooks were alive simultaneously (e.g. prewarming + block execution), the first drop caused the `MultiProofTask` to treat the block as complete and exit, silently discarding all state updates from the still-live second hook. This produced incorrect state roots.

## Fix

Introduces a shared `Arc<AtomicUsize>` reference counter attached to `PayloadHandle::to_multi_proof`. Each call to `state_hook()` increments the counter and wraps the sender in a `StateHookSender` that holds a clone of the `Arc`. On drop, the counter is decremented atomically; `FinishedStateUpdates` is sent **only when the last hook is dropped** (previous counter value == 1). This guarantees exactly-once delivery of the completion signal regardless of how many hooks were created.

### Additional improvement

Proof calculation errors are now forwarded through the sparse-trie channel as `Err(ParallelStateRootError)` instead of being swallowed. The sparse trie task propagates them via `?` so the caller surfaces a real error rather than silently receiving a stale/wrong root.

## Changed files

| File | Change |
|---|---|
| `payload_processor/mod.rs` | Add `AtomicUsize`/`Ordering` imports; change `to_multi_proof` field to carry a ref-count; update `state_hook()` to increment/share counter; update `spawn_sparse_trie_task` signature |
| `payload_processor/multiproof.rs` | Refactor `StateHookSender` to hold `ref_count`; implement ref-counted `Drop`; change `to_sparse_trie` channel type to `Result<SparseTrieUpdate, _>`; forward proof errors downstream |
| `payload_processor/sparse_trie.rs` | Update `updates` receiver type; propagate errors from channel via `?` |