### PR TITLE
fix: resolve #169 — [Critical] ProofCalculationError Causes Silent Wrong-State-Root Ok Return and inflight Counter Leak

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -25,6 +25,7 @@ use reth_evm::{
     ConfigureEvm, EvmEnvFor, OnStateHook, SpecFor, TxEnvFor,
 };
 use reth_primitives_traits::NodePrimitives;
+use reth_errors::ProviderError;
 use reth_provider::{
     providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, StateProviderFactory,
     StateReader,
@@ -180,7 +181,8 @@ where
             + Clone
             + 'static,
     {
-        let (to_sparse_trie, sparse_trie_rx) = channel();
+        let (to_sparse_trie, sparse_trie_rx) =
+            channel::<Result<SparseTrieUpdate, ProviderError>>();
         // spawn multiproof task, save the trie input
         let (trie_input, state_root_config) =
             MultiProofConfig::new_from_input(consistent_view, trie_input);
@@ -371,7 +373,7 @@ where
     /// Spawns the [`SparseTrieTask`] for this payload processor.
     fn spawn_sparse_trie_task<BPF>(
         &self,
-        sparse_trie_rx: mpsc::Receiver<SparseTrieUpdate>,
+        sparse_trie_rx: mpsc::Receiver<Result<SparseTrieUpdate, ProviderError>>,
         proof_task_handle: BPF,
         state_root_tx: mpsc::Sender<Result<StateRootComputeOutcome, ParallelStateRootError>>,
     ) where

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -634,7 +634,11 @@ pub(super) struct MultiProofTask<Factory: DatabaseProviderFactory> {
     /// Sender for state root related messages.
     tx: Sender<MultiProofMessage>,
     /// Sender for state updates emitted by this type.
-    to_sparse_trie: Sender<SparseTrieUpdate>,
+    ///
+    /// Carries `Ok(update)` for normal proof results and `Err(err)` to signal a proof calculation
+    /// failure so the sparse trie task can propagate the error rather than silently computing a
+    /// root from incomplete state.
+    to_sparse_trie: Sender<Result<SparseTrieUpdate, ProviderError>>,
     /// Proof targets that have been already fetched.
     fetched_proof_targets: MultiProofTargets,
     /// Tracks keys which have been added and removed throughout the entire block.
@@ -656,7 +660,7 @@ where
         config: MultiProofConfig<Factory>,
         executor: WorkloadExecutor,
         proof_task_handle: ProofTaskManagerHandle<FactoryTx<Factory>>,
-        to_sparse_trie: Sender<SparseTrieUpdate>,
+        to_sparse_trie: Sender<Result<SparseTrieUpdate, ProviderError>>,
         max_concurrency: usize,
     ) -> Self {
         let (tx, rx) = channel();
@@ -1007,7 +1011,7 @@ where
                             sequence_number,
                             SparseTrieUpdate { state, multiproof: Default::default() },
                         ) {
-                            let _ = self.to_sparse_trie.send(combined_update);
+                            let _ = self.to_sparse_trie.send(Ok(combined_update));
                         }
 
                         if self.is_done(
@@ -1047,7 +1051,7 @@ where
                         if let Some(combined_update) =
                             self.on_proof(proof_calculated.sequence_number, proof_calculated.update)
                         {
-                            let _ = self.to_sparse_trie.send(combined_update);
+                            let _ = self.to_sparse_trie.send(Ok(combined_update));
                         }
 
                         if self.is_done(
@@ -1068,6 +1072,17 @@ where
                             ?err,
                             "proof calculation error"
                         );
+                        // Decrement the inflight counter and drain any queued pending proofs so
+                        // the manager state stays consistent. Without this the counter leaks and
+                        // subsequent block processing would under-schedule proof work.
+                        self.multiproof_manager.on_calculation_complete();
+                        // Explicitly forward the error to the sparse trie task before dropping
+                        // `to_sparse_trie`. If we simply return here the channel closes and the
+                        // sparse trie interprets closure as normal completion, computing
+                        // `root_with_updates` on a partially-applied trie and returning
+                        // `Ok(<wrong_root>)`. Sending `Err` ensures the sparse trie propagates
+                        // the failure rather than silently accepting an incorrect state root.
+                        let _ = self.to_sparse_trie.send(Err(err));
                         return
                     }
                 },

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -3,6 +3,7 @@
 use crate::tree::payload_processor::multiproof::{MultiProofTaskMetrics, SparseTrieUpdate};
 use alloy_primitives::B256;
 use rayon::iter::{ParallelBridge, ParallelIterator};
+use reth_errors::ProviderError;
 use reth_trie::{updates::TrieUpdates, Nibbles};
 use reth_trie_parallel::root::ParallelStateRootError;
 use reth_trie_sparse::{
@@ -24,8 +25,12 @@ where
     BPF::AccountNodeProvider: TrieNodeProvider + Send + Sync,
     BPF::StorageNodeProvider: TrieNodeProvider + Send + Sync,
 {
-    /// Receives updates from the state root task.
-    pub(super) updates: mpsc::Receiver<SparseTrieUpdate>,
+    /// Receives updates from the multiproof task.
+    ///
+    /// Each message is `Ok(update)` for a normal proof result or `Err(err)` when a proof
+    /// calculation failed. An `Err` causes the sparse trie task to abort with that error rather
+    /// than computing a root from incomplete state.
+    pub(super) updates: mpsc::Receiver<Result<SparseTrieUpdate, ProviderError>>,
     /// `SparseStateTrie` used for computing the state root.
     pub(super) trie: SparseStateTrie<A, S>,
     pub(super) metrics: MultiProofTaskMetrics,
@@ -43,7 +48,7 @@ where
 {
     /// Creates a new sparse trie, pre-populating with a [`ClearedSparseStateTrie`].
     pub(super) fn new_with_cleared_trie(
-        updates: mpsc::Receiver<SparseTrieUpdate>,
+        updates: mpsc::Receiver<Result<SparseTrieUpdate, ProviderError>>,
         blinded_provider_factory: BPF,
         metrics: MultiProofTaskMetrics,
         sparse_state_trie: ClearedSparseStateTrie<A, S>,
@@ -77,11 +82,25 @@ where
 
         let mut num_iterations = 0;
 
-        while let Ok(mut update) = self.updates.recv() {
+        while let Ok(msg) = self.updates.recv() {
+            // Propagate any proof calculation error forwarded by the multiproof task.  Without
+            // this check a channel close (caused by the multiproof task returning on error) would
+            // be misinterpreted as normal completion and `root_with_updates` would be called on a
+            // partially-applied trie, producing a silently wrong state root.
+            let mut update = msg.map_err(|e| {
+                ParallelStateRootError::Other(format!("proof calculation error: {e:?}"))
+            })?;
             num_iterations += 1;
             let mut num_updates = 1;
-            while let Ok(next) = self.updates.try_recv() {
-                update.extend(next);
+            while let Ok(msg) = self.updates.try_recv() {
+                match msg {
+                    Ok(next) => update.extend(next),
+                    Err(e) => {
+                        return Err(ParallelStateRootError::Other(format!(
+                            "proof calculation error: {e:?}"
+                        )))
+                    }
+                }
                 num_updates += 1;
             }
 


### PR DESCRIPTION
Closes #169

## Root Cause

`MultiProofTask::run()` handled `MultiProofMessage::ProofCalculationError` by calling `return` immediately (line 1071), which had two silent failure modes:

1. **Wrong state root returned as `Ok`**: Dropping `self` closed the `to_sparse_trie` sender. The `SparseTrieTask` exited its `while let Ok(update) = self.updates.recv()` loop on channel close — treating it as normal completion — then called `root_with_updates` on a partially-applied trie and sent `Ok(StateRootComputeOutcome { state_root: <wrong_root> })`. The engine accepted the payload with an incorrect state root.

2. **`inflight` counter leak**: The early `return` bypassed `on_calculation_complete()`, leaving the `inflight` counter incremented and any queued `MultiproofInput` entries in `pending` silently dropped, causing under-scheduling of subsequent proof work.

## Fix

**`multiproof.rs`** — Change the `to_sparse_trie` channel element type from `SparseTrieUpdate` to `Result<SparseTrieUpdate, ProviderError>`:
- All normal proof results are wrapped in `Ok(update)` at their send sites.
- In the `ProofCalculationError` arm: call `on_calculation_complete()` first (fixes the inflight/pending leak), then send `Err(err)` over the channel before returning (ensures the sparse trie receives an explicit error).

**`sparse_trie.rs`** — Update `SparseTrieTask` to receive `Result<SparseTrieUpdate, ProviderError>`:
- On `Err(e)` from the channel (either as the primary `recv()` result or via `try_recv()` batch drain), immediately return `Err(ParallelStateRootError)`.
- This propagates up through `state_root_tx.send(result)` in `mod.rs`, so `PayloadHandle::state_root()` correctly returns `Err` instead of `Ok(<wrong_root>)`.

**`mod.rs`** — Update channel creation and `spawn_sparse_trie_task` signature to match the new `Result<SparseTrieUpdate, ProviderError>` element type.

## Affected Files

- `crates/engine/tree/src/tree/payload_processor/multiproof.rs`
- `crates/engine/tree/src/tree/payload_processor/sparse_trie.rs`
- `crates/engine/tree/src/tree/payload_processor/mod.rs`