### PR TITLE
fix: resolve #176 — [High] removed_accounts Ghost Entries When Storage Error Triggers Early Return in update_sparse_trie

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -219,8 +219,15 @@ where
     let mut removed_accounts = Vec::new();
 
     // Update account storage roots
+    let mut storage_error = None;
     for result in rx {
-        let (address, storage_trie) = result?;
+        let (address, storage_trie) = match result {
+            Ok(val) => val,
+            Err(e) => {
+                storage_error = Some(e);
+                break;
+            }
+        };
         trie.insert_storage_trie(address, storage_trie);
 
         if let Some(account) = state.accounts.remove(&address) {
@@ -243,19 +250,28 @@ where
         }
     }
 
-    // Update accounts
-    for (address, account) in state.accounts {
-        trace!(target: "engine::root::sparse", ?address, "Updating account");
-        if !trie.update_account(address, account.unwrap_or_default(), blinded_provider_factory)? {
-            removed_accounts.push(address);
+    // If a storage error occurred, skip further account updates but still remove any accounts
+    // that were already queued for removal before the error was encountered.
+    if storage_error.is_none() {
+        // Update accounts
+        for (address, account) in state.accounts {
+            trace!(target: "engine::root::sparse", ?address, "Updating account");
+            if !trie.update_account(address, account.unwrap_or_default(), blinded_provider_factory)? {
+                removed_accounts.push(address);
+            }
         }
     }
 
-    // Remove accounts
+    // Remove accounts — always run so that accounts queued before a storage error are not left
+    // as ghost leaf nodes in the recycled trie.
     for address in removed_accounts {
         trace!(target: "trie::sparse", ?address, "Removing account");
         let nibbles = Nibbles::unpack(address);
         trie.remove_account_leaf(&nibbles, blinded_provider_factory)?;
+    }
+
+    if let Some(e) = storage_error {
+        return Err(e);
     }
 
     let elapsed_before = started_at.elapsed();


### PR DESCRIPTION
Closes #176

## Problem

`update_sparse_trie()` used `result?` inside the `for result in rx` loop to process storage trie results. When a storage error occurred, this propagated the error immediately via the `?` operator, returning before the `removed_accounts` cleanup loop ever ran.

Accounts pushed to `removed_accounts` during successful iterations (before the first error) were never removed from the account trie. These accounts remained as ghost leaf nodes with stale values in the recycled trie, causing incorrect state root computation for all subsequent blocks.

## Fix

Instead of propagating the storage error immediately with `?`, the error is now collected in a `storage_error: Option<_>` variable and the loop breaks. This allows the function to:

1. **Skip** further account updates (correct — those would be based on incomplete state)
2. **Always run** the `remove_account_leaf` loop for accounts already queued before the error
3. **Re-raise** the storage error after cleanup

```rust
// Before — early return skips removed_accounts:
let (address, storage_trie) = result?;

// After — error collected, cleanup always runs:
let (address, storage_trie) = match result {
    Ok(val) => val,
    Err(e) => { storage_error = Some(e); break; }
};
// ... account removal loop always executes ...
if let Some(e) = storage_error { return Err(e); }
```

## Impact

Without this fix, any storage error during block processing leaves deleted accounts as ghost entries in the recycled sparse trie, producing a divergent chain state for all subsequent blocks.