### PR TITLE
fix: resolve #183 — [Critical] Non-Atomic insert_state Leaves Bytecodes in Live

### DIFF
--- a/crates/engine/tree/src/tree/payload_processor/mod.rs
+++ b/crates/engine/tree/src/tree/payload_processor/mod.rs
@@ -25,6 +25,7 @@ use reth_evm::{
     ConfigureEvm, EvmEnvFor, OnStateHook, SpecFor, TxEnvFor,
 };
 use reth_primitives_traits::NodePrimitives;
+use reth_errors::ProviderError;
 use reth_provider::{
     providers::ConsistentDbView, BlockReader, DatabaseProviderFactory, StateProviderFactory,
     StateReader,
@@ -180,7 +181,8 @@ where
             + Clone
             + 'static,
     {
-        let (to_sparse_trie, sparse_trie_rx) = channel();
+        let (to_sparse_trie, sparse_trie_rx) =
+            channel::<Result<SparseTrieUpdate, ProviderError>>();
         // spawn multiproof task, save the trie input
         let (trie_input, state_root_config) =
             MultiProofConfig::new_from_input(consistent_view, trie_input);
@@ -371,7 +373,7 @@ where
     /// Spawns the [`SparseTrieTask`] for this payload processor.
     fn spawn_sparse_trie_task<BPF>(
         &self,
-        sparse_trie_rx: mpsc::Receiver<SparseTrieUpdate>,
+        sparse_trie_rx: mpsc::Receiver<Result<SparseTrieUpdate, ProviderError>>,
         proof_task_handle: BPF,
         state_root_tx: mpsc::Sender<Result<StateRootComputeOutcome, ParallelStateRootError>>,
     ) where

--- a/crates/engine/tree/src/tree/payload_processor/multiproof.rs
+++ b/crates/engine/tree/src/tree/payload_processor/multiproof.rs
@@ -634,7 +634,11 @@ pub(super) struct MultiProofTask<Factory: DatabaseProviderFactory> {
     /// Sender for state root related messages.
     tx: Sender<MultiProofMessage>,
     /// Sender for state updates emitted by this type.
-    to_sparse_trie: Sender<SparseTrieUpdate>,
+    ///
+    /// Carries `Ok(update)` for normal proof results and `Err(err)` to signal a proof calculation
+    /// failure so the sparse trie task can propagate the error rather than silently computing a
+    /// root from incomplete state.
+    to_sparse_trie: Sender<Result<SparseTrieUpdate, ProviderError>>,
     /// Proof targets that have been already fetched.
     fetched_proof_targets: MultiProofTargets,
     /// Tracks keys which have been added and removed throughout the entire block.
@@ -656,7 +660,7 @@ where
         config: MultiProofConfig<Factory>,
         executor: WorkloadExecutor,
         proof_task_handle: ProofTaskManagerHandle<FactoryTx<Factory>>,
-        to_sparse_trie: Sender<SparseTrieUpdate>,
+        to_sparse_trie: Sender<Result<SparseTrieUpdate, ProviderError>>,
         max_concurrency: usize,
     ) -> Self {
         let (tx, rx) = channel();
@@ -1007,7 +1011,7 @@ where
                             sequence_number,
                             SparseTrieUpdate { state, multiproof: Default::default() },
                         ) {
-                            let _ = self.to_sparse_trie.send(combined_update);
+                            let _ = self.to_sparse_trie.send(Ok(combined_update));
                         }
 
                         if self.is_done(
@@ -1047,7 +1051,7 @@ where
                         if let Some(combined_update) =
                             self.on_proof(proof_calculated.sequence_number, proof_calculated.update)
                         {
-                            let _ = self.to_sparse_trie.send(combined_update);
+                            let _ = self.to_sparse_trie.send(Ok(combined_update));
                         }
 
                         if self.is_done(
@@ -1068,6 +1072,17 @@ where
                             ?err,
                             "proof calculation error"
                         );
+                        // Decrement the inflight counter and drain any queued pending proofs so
+                        // the manager state stays consistent. Without this the counter leaks and
+                        // subsequent block processing would under-schedule proof work.
+                        self.multiproof_manager.on_calculation_complete();
+                        // Explicitly forward the error to the sparse trie task before dropping
+                        // `to_sparse_trie`. If we simply return here the channel closes and the
+                        // sparse trie interprets closure as normal completion, computing
+                        // `root_with_updates` on a partially-applied trie and returning
+                        // `Ok(<wrong_root>)`. Sending `Err` ensures the sparse trie propagates
+                        // the failure rather than silently accepting an incorrect state root.
+                        let _ = self.to_sparse_trie.send(Err(err));
                         return
                     }
                 },

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -238,8 +238,15 @@ where
     let mut removed_accounts = Vec::new();
 
     // Update account storage roots
+    let mut storage_error = None;
     for result in rx {
-        let (address, storage_trie) = result?;
+        let (address, storage_trie) = match result {
+            Ok(val) => val,
+            Err(e) => {
+                storage_error = Some(e);
+                break;
+            }
+        };
         trie.insert_storage_trie(address, storage_trie);
 
         if let Some(account) = state.accounts.remove(&address) {
@@ -262,19 +269,28 @@ where
         }
     }
 
-    // Update accounts
-    for (address, account) in state.accounts {
-        trace!(target: "engine::root::sparse", ?address, "Updating account");
-        if !trie.update_account(address, account.unwrap_or_default(), blinded_provider_factory)? {
-            removed_accounts.push(address);
+    // If a storage error occurred, skip further account updates but still remove any accounts
+    // that were already queued for removal before the error was encountered.
+    if storage_error.is_none() {
+        // Update accounts
+        for (address, account) in state.accounts {
+            trace!(target: "engine::root::sparse", ?address, "Updating account");
+            if !trie.update_account(address, account.unwrap_or_default(), blinded_provider_factory)? {
+                removed_accounts.push(address);
+            }
         }
     }
 
-    // Remove accounts
+    // Remove accounts — always run so that accounts queued before a storage error are not left
+    // as ghost leaf nodes in the recycled trie.
     for address in removed_accounts {
         trace!(target: "trie::sparse", ?address, "Removing account");
         let nibbles = Nibbles::unpack(address);
         trie.remove_account_leaf(&nibbles, blinded_provider_factory)?;
+    }
+
+    if let Some(e) = storage_error {
+        return Err(e);
     }
 
     let elapsed_before = started_at.elapsed();

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -3,6 +3,7 @@
 use crate::tree::payload_processor::multiproof::{MultiProofTaskMetrics, SparseTrieUpdate};
 use alloy_primitives::B256;
 use rayon::iter::{ParallelBridge, ParallelIterator};
+use reth_errors::ProviderError;
 use reth_trie::{updates::TrieUpdates, Nibbles};
 use reth_trie_parallel::root::ParallelStateRootError;
 use reth_trie_sparse::{
@@ -24,8 +25,12 @@ where
     BPF::AccountNodeProvider: TrieNodeProvider + Send + Sync,
     BPF::StorageNodeProvider: TrieNodeProvider + Send + Sync,
 {
-    /// Receives updates from the state root task.
-    pub(super) updates: mpsc::Receiver<SparseTrieUpdate>,
+    /// Receives updates from the multiproof task.
+    ///
+    /// Each message is `Ok(update)` for a normal proof result or `Err(err)` when a proof
+    /// calculation failed. An `Err` causes the sparse trie task to abort with that error rather
+    /// than computing a root from incomplete state.
+    pub(super) updates: mpsc::Receiver<Result<SparseTrieUpdate, ProviderError>>,
     /// `SparseStateTrie` used for computing the state root.
     pub(super) trie: SparseStateTrie<A, S>,
     pub(super) metrics: MultiProofTaskMetrics,
@@ -43,7 +48,7 @@ where
 {
     /// Creates a new sparse trie, pre-populating with a [`ClearedSparseStateTrie`].
     pub(super) fn new_with_cleared_trie(
-        updates: mpsc::Receiver<SparseTrieUpdate>,
+        updates: mpsc::Receiver<Result<SparseTrieUpdate, ProviderError>>,
         blinded_provider_factory: BPF,
         metrics: MultiProofTaskMetrics,
         sparse_state_trie: ClearedSparseStateTrie<A, S>,
@@ -77,11 +82,25 @@ where
 
         let mut num_iterations = 0;
 
-        while let Ok(mut update) = self.updates.recv() {
+        while let Ok(msg) = self.updates.recv() {
+            // Propagate any proof calculation error forwarded by the multiproof task.  Without
+            // this check a channel close (caused by the multiproof task returning on error) would
+            // be misinterpreted as normal completion and `root_with_updates` would be called on a
+            // partially-applied trie, producing a silently wrong state root.
+            let mut update = msg.map_err(|e| {
+                ParallelStateRootError::Other(format!("proof calculation error: {e:?}"))
+            })?;
             num_iterations += 1;
             let mut num_updates = 1;
-            while let Ok(next) = self.updates.try_recv() {
-                update.extend(next);
+            while let Ok(msg) = self.updates.try_recv() {
+                match msg {
+                    Ok(next) => update.extend(next),
+                    Err(e) => {
+                        return Err(ParallelStateRootError::Other(format!(
+                            "proof calculation error: {e:?}"
+                        )))
+                    }
+                }
                 num_updates += 1;
             }
 


### PR DESCRIPTION
Closes #183

## Problem

`update_sparse_trie()` propagated a storage error immediately via `result?` inside the `for result in rx` loop. This skipped the `removed_accounts` cleanup step entirely.

Accounts that had already been pushed to `removed_accounts` during successful storage processing (before the first error) were never removed from the account trie. These accounts remained as ghost leaf nodes with stale values in the recycled `SparseStateTrie`, causing **incorrect state root computation for all subsequent blocks**.

## Fix

Instead of propagating the storage error immediately with `?`, collect it in a `storage_error: Option<_>` variable and `break` out of the loop. Then:

- Skip further account updates when a storage error is present (no partial writes).
- **Always** run the `remove_account_leaf` loop so that any accounts queued before the error are cleaned up from the trie.
- Re-raise the stored error after cleanup.

## Impact

Without this fix, a single storage processing failure permanently corrupts the recycled trie, resulting in wrong state roots for every block processed after the failure.