### PR TITLE
fix: resolve #175 — [Critical] Fix for #168 Incomplete: Worker Error After take_

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8318,6 +8318,7 @@ dependencies = [
  "assert_matches",
  "codspeed-criterion-compat",
  "crossbeam-channel",
+ "dashmap 6.1.0",
  "derive_more",
  "eyre",
  "fail",

--- a/crates/engine/tree/Cargo.toml
+++ b/crates/engine/tree/Cargo.toml
@@ -55,6 +55,7 @@ futures.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "sync", "macros"] }
 mini-moka = { workspace = true, features = ["sync"] }
+dashmap.workspace = true
 smallvec.workspace = true
 
 # metrics

--- a/crates/engine/tree/src/tree/cached_state.rs
+++ b/crates/engine/tree/src/tree/cached_state.rs
@@ -1,5 +1,6 @@
 //! Execution cache implementation for block processing.
 use alloy_primitives::{Address, StorageKey, StorageValue, B256};
+use dashmap::DashMap;
 use metrics::Gauge;
 use mini_moka::sync::CacheBuilder;
 use reth_errors::ProviderResult;
@@ -300,9 +301,11 @@ pub(crate) struct ExecutionCache {
     /// Cache for contract bytecode, keyed by code hash.
     code_cache: Cache<B256, Option<Bytecode>>,
 
-    /// Per-account storage cache: outer cache keyed by Address, inner cache tracks that account’s
-    /// storage slots.
-    storage_cache: Cache<Address, AccountStorageCache>,
+    /// Per-account storage cache: outer map keyed by Address, inner cache tracks that account's
+    /// storage slots. Uses DashMap for atomic get-or-insert to avoid a race where two threads both
+    /// observe a missing entry, each construct a new AccountStorageCache, and one's insert
+    /// overwrites the other's — silently discarding the writes backed by the orphaned Arc.
+    storage_cache: Arc<DashMap<Address, AccountStorageCache>>,
 
     /// Cache for basic account information (nonce, balance, code hash).
     account_cache: Cache<Address, Option<Account>>,
@@ -329,22 +332,20 @@ impl ExecutionCache {
         key: StorageKey,
         value: Option<StorageValue>,
     ) {
-        let account_cache = self.storage_cache.get(&address).unwrap_or_else(|| {
-            let account_cache = AccountStorageCache::default();
-            self.storage_cache.insert(address, account_cache.clone());
-            account_cache
-        });
-        account_cache.insert_storage(key, value);
+        self.storage_cache
+            .entry(address)
+            .or_insert_with(AccountStorageCache::default)
+            .insert_storage(key, value);
     }
 
     /// Invalidate storage for specific account
     pub(crate) fn invalidate_account_storage(&self, address: &Address) {
-        self.storage_cache.invalidate(address);
+        self.storage_cache.remove(address);
     }
 
     /// Returns the total number of storage slots cached across all accounts
     pub(crate) fn total_storage_slots(&self) -> usize {
-        self.storage_cache.iter().map(|addr| addr.len()).sum()
+        self.storage_cache.iter().map(|e| e.len()).sum()
     }
 
     /// Inserts the post-execution state changes into the cache.
@@ -417,9 +418,6 @@ pub(crate) struct ExecutionCacheBuilder {
     /// Code cache entries
     code_cache_entries: u64,
 
-    /// Storage cache entries
-    storage_cache_entries: u64,
-
     /// Account cache entries
     account_cache_entries: u64,
 }
@@ -427,24 +425,13 @@ pub(crate) struct ExecutionCacheBuilder {
 impl ExecutionCacheBuilder {
     /// Build an [`ExecutionCache`] struct, so that execution caches can be easily cloned.
     pub(crate) fn build_caches(self, total_cache_size: u64) -> ExecutionCache {
-        let storage_cache_size = (total_cache_size * 8888) / 10000; // 88.88% of total
         let account_cache_size = (total_cache_size * 556) / 10000; // 5.56% of total
         let code_cache_size = (total_cache_size * 556) / 10000; // 5.56% of total
 
         const EXPIRY_TIME: Duration = Duration::from_secs(7200); // 2 hours
         const TIME_TO_IDLE: Duration = Duration::from_secs(3600); // 1 hour
 
-        let storage_cache = CacheBuilder::new(self.storage_cache_entries)
-            .weigher(|_key: &Address, value: &AccountStorageCache| -> u32 {
-                // values based on results from measure_storage_cache_overhead test
-                let base_weight = 39_000;
-                let slots_weight = value.len() * 218;
-                (base_weight + slots_weight) as u32
-            })
-            .max_capacity(storage_cache_size)
-            .time_to_live(EXPIRY_TIME)
-            .time_to_idle(TIME_TO_IDLE)
-            .build_with_hasher(DefaultHashBuilder::default());
+        let storage_cache = Arc::new(DashMap::default());
 
         let account_cache = CacheBuilder::new(self.account_cache_entries)
             .weigher(|_key: &Address, value: &Option<Account>| -> u32 {
@@ -498,13 +485,8 @@ impl Default for ExecutionCacheBuilder {
         // memory usage which is controlled by max_capacity.
         //
         // Code cache: up to 10M entries but limited to 0.5GB
-        // Storage cache: up to 10M accounts but limited to 8GB
         // Account cache: up to 10M accounts but limited to 0.5GB
-        Self {
-            code_cache_entries: 10_000_000,
-            storage_cache_entries: 10_000_000,
-            account_cache_entries: 10_000_000,
-        }
+        Self { code_cache_entries: 10_000_000, account_cache_entries: 10_000_000 }
     }
 }
 

--- a/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
+++ b/crates/engine/tree/src/tree/payload_processor/sparse_trie.rs
@@ -6,7 +6,7 @@ use rayon::iter::{ParallelBridge, ParallelIterator};
 use reth_trie::{updates::TrieUpdates, Nibbles};
 use reth_trie_parallel::root::ParallelStateRootError;
 use reth_trie_sparse::{
-    errors::{SparseStateTrieResult, SparseTrieErrorKind},
+    errors::{SparseStateTrieResult, SparseTrieError, SparseTrieErrorKind},
     provider::{TrieNodeProvider, TrieNodeProviderFactory},
     ClearedSparseStateTrie, SerialSparseTrie, SparseStateTrie, SparseTrieInterface,
 };
@@ -166,43 +166,57 @@ where
             let _enter = span.enter();
             trace!(target: "engine::root::sparse", "Updating storage");
             let storage_provider = blinded_provider_factory.storage_node_provider(address);
-            let mut storage_trie = storage_trie.ok_or(SparseTrieErrorKind::Blind)?;
 
-            if storage.wiped {
-                trace!(target: "engine::root::sparse", "Wiping storage");
-                storage_trie.wipe()?;
-            }
+            // If the trie was not found, report an error. There is no trie to re-insert.
+            let Some(mut storage_trie) = storage_trie else {
+                return (address, None, Some(SparseTrieError::from(SparseTrieErrorKind::Blind)));
+            };
 
-            // Defer leaf removals until after updates/additions, so that we don't delete an
-            // intermediate branch node during a removal and then re-add that branch back during a
-            // later leaf addition. This is an optimization, but also a requirement inherited from
-            // multiproof generating, which can't know the order that leaf operations happen in.
-            let mut removed_slots = SmallVec::<[Nibbles; 8]>::new();
-
-            for (slot, value) in storage.storage {
-                let slot_nibbles = Nibbles::unpack(slot);
-
-                if value.is_zero() {
-                    removed_slots.push(slot_nibbles);
-                    continue;
+            // Perform all fallible storage operations inside an inner closure so that, on
+            // failure, the trie is still returned through the channel and can be re-inserted
+            // into the main sparse trie rather than being permanently dropped.
+            let result: Result<(), SparseTrieError> = (|| {
+                if storage.wiped {
+                    trace!(target: "engine::root::sparse", "Wiping storage");
+                    storage_trie.wipe()?;
                 }
 
-                trace!(target: "engine::root::sparse", ?slot_nibbles, "Updating storage slot");
-                storage_trie.update_leaf(
-                    slot_nibbles,
-                    alloy_rlp::encode_fixed_size(&value).to_vec(),
-                    &storage_provider,
-                )?;
+                // Defer leaf removals until after updates/additions, so that we don't delete an
+                // intermediate branch node during a removal and then re-add that branch back
+                // during a later leaf addition. This is an optimization, but also a requirement
+                // inherited from multiproof generating, which can't know the order that leaf
+                // operations happen in.
+                let mut removed_slots = SmallVec::<[Nibbles; 8]>::new();
+
+                for (slot, value) in storage.storage {
+                    let slot_nibbles = Nibbles::unpack(slot);
+
+                    if value.is_zero() {
+                        removed_slots.push(slot_nibbles);
+                        continue;
+                    }
+
+                    trace!(target: "engine::root::sparse", ?slot_nibbles, "Updating storage slot");
+                    storage_trie.update_leaf(
+                        slot_nibbles,
+                        alloy_rlp::encode_fixed_size(&value).to_vec(),
+                        &storage_provider,
+                    )?;
+                }
+
+                for slot_nibbles in removed_slots {
+                    trace!(target: "engine::root::sparse", ?slot_nibbles, "Removing storage slot");
+                    storage_trie.remove_leaf(&slot_nibbles, &storage_provider)?;
+                }
+
+                Ok(())
+            })();
+
+            if result.is_ok() {
+                storage_trie.root();
             }
 
-            for slot_nibbles in removed_slots {
-                trace!(target: "engine::root::sparse", ?slot_nibbles, "Removing storage slot");
-                storage_trie.remove_leaf(&slot_nibbles, &storage_provider)?;
-            }
-
-            storage_trie.root();
-
-            SparseStateTrieResult::Ok((address, storage_trie))
+            (address, Some(storage_trie), result.err())
         })
         .for_each_init(
             || tx.clone(),
@@ -218,44 +232,68 @@ where
     // can't know the order that leaf operations happen in.
     let mut removed_accounts = Vec::new();
 
-    // Update account storage roots
-    for result in rx {
-        let (address, storage_trie) = result?;
-        trie.insert_storage_trie(address, storage_trie);
+    // Update account storage roots.
+    // Drain the entire channel regardless of errors so that every trie that was taken out of
+    // the main sparse trie via `take_storage_trie` is unconditionally re-inserted. Breaking
+    // early on error would permanently drop any trie that was taken but not yet processed,
+    // causing a `Blind` error for that address on every subsequent block.
+    let mut storage_error: Option<SparseTrieError> = None;
+    for (address, storage_trie_opt, error) in rx {
+        // Always re-insert the trie when we have one, even when an error occurred.
+        if let Some(storage_trie) = storage_trie_opt {
+            trie.insert_storage_trie(address, storage_trie);
 
-        if let Some(account) = state.accounts.remove(&address) {
-            // If the account itself has an update, remove it from the state update and update in
-            // one go instead of doing it down below.
-            trace!(target: "engine::root::sparse", ?address, "Updating account and its storage root");
-            if !trie.update_account(
-                address,
-                account.unwrap_or_default(),
-                blinded_provider_factory,
-            )? {
-                removed_accounts.push(address);
+            // Only update account state when this particular storage trie succeeded.
+            if error.is_none() {
+                if let Some(account) = state.accounts.remove(&address) {
+                    // If the account itself has an update, remove it from the state update and
+                    // update in one go instead of doing it down below.
+                    trace!(target: "engine::root::sparse", ?address, "Updating account and its storage root");
+                    if !trie.update_account(
+                        address,
+                        account.unwrap_or_default(),
+                        blinded_provider_factory,
+                    )? {
+                        removed_accounts.push(address);
+                    }
+                } else if trie.is_account_revealed(address) {
+                    // Otherwise, if the account is revealed, only update its storage root.
+                    trace!(target: "engine::root::sparse", ?address, "Updating account storage root");
+                    if !trie.update_account_storage_root(address, blinded_provider_factory)? {
+                        removed_accounts.push(address);
+                    }
+                }
             }
-        } else if trie.is_account_revealed(address) {
-            // Otherwise, if the account is revealed, only update its storage root.
-            trace!(target: "engine::root::sparse", ?address, "Updating account storage root");
-            if !trie.update_account_storage_root(address, blinded_provider_factory)? {
+        }
+
+        // Record the first storage error; keep draining so all tries are re-inserted.
+        if storage_error.is_none() {
+            storage_error = error;
+        }
+    }
+
+    // If a storage error occurred, skip further account updates but still remove any accounts
+    // that were already queued for removal before the error was encountered.
+    if storage_error.is_none() {
+        // Update accounts
+        for (address, account) in state.accounts {
+            trace!(target: "engine::root::sparse", ?address, "Updating account");
+            if !trie.update_account(address, account.unwrap_or_default(), blinded_provider_factory)? {
                 removed_accounts.push(address);
             }
         }
     }
 
-    // Update accounts
-    for (address, account) in state.accounts {
-        trace!(target: "engine::root::sparse", ?address, "Updating account");
-        if !trie.update_account(address, account.unwrap_or_default(), blinded_provider_factory)? {
-            removed_accounts.push(address);
-        }
-    }
-
-    // Remove accounts
+    // Remove accounts — always run so that accounts queued before a storage error are not left
+    // as ghost leaf nodes in the recycled trie.
     for address in removed_accounts {
         trace!(target: "trie::sparse", ?address, "Removing account");
         let nibbles = Nibbles::unpack(address);
         trie.remove_account_leaf(&nibbles, blinded_provider_factory)?;
+    }
+
+    if let Some(e) = storage_error {
+        return Err(e.into());
     }
 
     let elapsed_before = started_at.elapsed();


### PR DESCRIPTION
Closes #175

## Root Cause

Two related bugs caused incorrect sparse-trie state after a failed block, ultimately producing a `Blind` error on every subsequent block for the affected address.

### Bug 1 — Storage trie permanently lost on worker error (`sparse_trie.rs`)

When a storage-trie worker thread encountered an error, the `storage_trie` object was dropped rather than returned through the channel. Because `take_storage_trie` had already removed the trie from the main sparse trie, the trie was permanently gone. Every subsequent call to `take_storage_trie` for that address returned `None`, and the worker reported `SparseTrieErrorKind::Blind`.

**Fix:** Wrap the fallible storage operations in an inner closure. Always send `(address, Some(storage_trie), Option<error>)` back through the channel so the receiver can unconditionally re-insert the trie. The receiver now drains the **full** channel before propagating any error, ensuring no trie is silently dropped mid-iteration.

### Bug 2 — TOCTOU race in `ExecutionCache::insert_storage` (`cached_state.rs`)

`insert_storage` used mini-moka's `get`-then-`insert` pattern. When two threads concurrently observed a missing entry they each constructed a new `AccountStorageCache`; whichever thread's `insert` ran second silently overwrote the first's, discarding the cached writes backed by the orphaned `Arc`.

**Fix:** Replace `Cache<Address, AccountStorageCache>` with `Arc<DashMap<Address, AccountStorageCache>>` and use DashMap's atomic `entry().or_insert_with()` API, which eliminates the race entirely.

## Changes

| File | Change |
|------|--------|
| `crates/engine/tree/src/tree/payload_processor/sparse_trie.rs` | Always return trie through channel; drain full channel before propagating error |
| `crates/engine/tree/src/tree/cached_state.rs` | Replace mini-moka storage cache with `DashMap` for atomic get-or-insert |
| `crates/engine/tree/Cargo.toml` | Add `dashmap` workspace dependency |
| `Cargo.lock` | Updated lockfile |