### PR TITLE
fix: resolve #206 — [High] Persistence service death is not fatal to t

### DIFF
--- a/crates/engine/service/src/service.rs
+++ b/crates/engine/service/src/service.rs
@@ -94,7 +94,7 @@ where
 
         let downloader = BasicBlockDownloader::new(client, consensus.clone());
 
-        let persistence_handle =
+        let (persistence_handle, persistence_liveness) =
             PersistenceHandle::<EthPrimitives>::spawn_service(provider, pruner, sync_metrics_tx);
 
         let canonical_in_memory_state = blockchain_db.canonical_in_memory_state();
@@ -104,6 +104,7 @@ where
             consensus,
             payload_validator,
             persistence_handle,
+            persistence_liveness,
             payload_builder,
             canonical_in_memory_state,
             tree_config,

--- a/crates/engine/tree/src/persistence.rs
+++ b/crates/engine/tree/src/persistence.rs
@@ -28,7 +28,7 @@ use std::{
     time::Instant,
 };
 use thiserror::Error;
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, watch};
 use tracing::{debug, error, info};
 
 /// Writes parts of reth's in memory tree state to the database and static files.
@@ -413,11 +413,15 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
     }
 
     /// Create a new [`PersistenceHandle`], and spawn the persistence service.
+    ///
+    /// Returns a tuple of the handle and a liveness receiver. The liveness receiver holds `true`
+    /// while the service is running and transitions to `false` when the service exits for any
+    /// reason. Callers should treat a `false` value as a fatal condition.
     pub fn spawn_service<N>(
         provider_factory: ProviderFactory<N>,
         pruner: PrunerWithFactory<ProviderFactory<N>>,
         sync_metrics_tx: MetricEventsSender,
-    ) -> PersistenceHandle<N::Primitives>
+    ) -> (PersistenceHandle<N::Primitives>, watch::Receiver<bool>)
     where
         N: ProviderNodeTypes,
     {
@@ -427,19 +431,25 @@ impl<T: NodePrimitives> PersistenceHandle<T> {
         // construct persistence handle
         let persistence_handle = PersistenceHandle::new(db_service_tx);
 
+        // liveness channel: true = alive, false = dead
+        let (liveness_tx, liveness_rx) = watch::channel(true);
+
         // spawn the persistence service
         let db_service =
             PersistenceService::new(provider_factory, db_service_rx, pruner, sync_metrics_tx);
         std::thread::Builder::new()
             .name("Persistence Service".to_string())
-            .spawn(|| {
+            .spawn(move || {
                 if let Err(err) = db_service.run() {
                     error!(target: "engine::persistence", ?err, "Persistence service failed");
                 }
+                // Signal that the service has exited (either cleanly or due to error).
+                // Receivers observing `false` should treat this as a fatal condition.
+                let _ = liveness_tx.send(false);
             })
             .unwrap();
 
-        persistence_handle
+        (persistence_handle, liveness_rx)
     }
 
     /// Sends a specific [`PersistenceAction`] in the contained channel. The caller is responsible
@@ -517,7 +527,7 @@ mod tests {
             Pruner::new_with_factory(provider.clone(), vec![], 5, 0, None, finished_exex_height_rx);
 
         let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
-        PersistenceHandle::<EthPrimitives>::spawn_service(provider, pruner, sync_metrics_tx)
+        PersistenceHandle::<EthPrimitives>::spawn_service(provider, pruner, sync_metrics_tx).0
     }
 
     #[tokio::test]

--- a/crates/engine/tree/src/tree/error.rs
+++ b/crates/engine/tree/src/tree/error.rs
@@ -19,6 +19,10 @@ pub enum AdvancePersistenceError {
     /// A provider error
     #[error(transparent)]
     Provider(#[from] ProviderError),
+    /// The persistence service thread has exited. All subsequent sends will fail and
+    /// in-memory state can no longer be durably committed to disk.
+    #[error("Persistence service has died")]
+    PersistenceServiceDied,
     /// Missing ancestor.
     ///
     /// This error occurs when we need to compute the state root for a block with missing trie

--- a/crates/engine/tree/src/tree/mod.rs
+++ b/crates/engine/tree/src/tree/mod.rs
@@ -57,6 +57,7 @@ use std::{
 use tokio::sync::{
     mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
     oneshot::{self, error::TryRecvError},
+    watch,
 };
 use tracing::*;
 
@@ -309,6 +310,9 @@ where
     outgoing: UnboundedSender<EngineApiEvent<N>>,
     /// Channels to the persistence layer.
     persistence: PersistenceHandle<N>,
+    /// Liveness signal for the persistence service. Holds `true` while the service is running;
+    /// transitions to `false` when the service exits. `None` means no liveness check (tests).
+    persistence_liveness: Option<watch::Receiver<bool>>,
     /// Tracks the state changes of the persistence task.
     persistence_state: PersistenceState,
     /// Flag indicating the state of the node's backfill synchronization process.
@@ -398,6 +402,7 @@ where
             incoming,
             outgoing,
             persistence,
+            persistence_liveness: None,
             persistence_state,
             backfill_sync_state: BackfillSyncState::Idle,
             state,
@@ -412,6 +417,15 @@ where
         }
     }
 
+    /// Attach a liveness receiver for the persistence service.
+    ///
+    /// When the receiver transitions to `false`, the engine treats it as a fatal condition and
+    /// stops processing. Call this after [`Self::new`] when a real persistence service is used.
+    pub fn with_persistence_liveness(mut self, liveness: watch::Receiver<bool>) -> Self {
+        self.persistence_liveness = Some(liveness);
+        self
+    }
+
     /// Creates a new [`EngineApiTreeHandler`] instance and spawns it in its
     /// own thread.
     ///
@@ -423,6 +437,7 @@ where
         consensus: Arc<dyn FullConsensus<N, Error = ConsensusError>>,
         payload_validator: V,
         persistence: PersistenceHandle<N>,
+        persistence_liveness: watch::Receiver<bool>,
         payload_builder: PayloadBuilderHandle<T>,
         canonical_in_memory_state: CanonicalInMemoryState<N>,
         config: TreeConfig,
@@ -459,7 +474,8 @@ where
             config,
             kind,
             evm_config,
-        );
+        )
+        .with_persistence_liveness(persistence_liveness);
         let incoming = task.incoming_tx.clone();
         std::thread::Builder::new().name("Engine Task".to_string()).spawn(|| task.run()).unwrap();
         (incoming, outgoing)
@@ -1352,24 +1368,41 @@ where
         }
     }
 
+    /// Returns an error if the persistence service has exited.
+    fn check_persistence_alive(&self) -> Result<(), AdvancePersistenceError> {
+        if let Some(liveness) = &self.persistence_liveness {
+            if !*liveness.borrow() {
+                return Err(AdvancePersistenceError::PersistenceServiceDied);
+            }
+        }
+        Ok(())
+    }
+
     /// Helper method to remove blocks and set the persistence state. This ensures we keep track of
     /// the current persistence action while we're removing blocks.
-    fn remove_blocks(&mut self, new_tip_num: u64) {
+    fn remove_blocks(&mut self, new_tip_num: u64) -> Result<(), AdvancePersistenceError> {
         debug!(target: "engine::tree", ?new_tip_num, last_persisted_block_number=?self.persistence_state.last_persisted_block.number, "Removing blocks using persistence task");
         if new_tip_num < self.persistence_state.last_persisted_block.number {
             debug!(target: "engine::tree", ?new_tip_num, "Starting remove blocks job");
+            self.check_persistence_alive()?;
             let (tx, rx) = oneshot::channel();
-            let _ = self.persistence.remove_blocks_above(new_tip_num, tx);
+            self.persistence
+                .remove_blocks_above(new_tip_num, tx)
+                .map_err(|_| AdvancePersistenceError::PersistenceServiceDied)?;
             self.persistence_state.start_remove(new_tip_num, rx);
         }
+        Ok(())
     }
 
     /// Helper method to save blocks and set the persistence state. This ensures we keep track of
     /// the current persistence action while we're saving blocks.
-    fn persist_blocks(&mut self, blocks_to_persist: Vec<ExecutedBlockWithTrieUpdates<N>>) {
+    fn persist_blocks(
+        &mut self,
+        blocks_to_persist: Vec<ExecutedBlockWithTrieUpdates<N>>,
+    ) -> Result<(), AdvancePersistenceError> {
         if blocks_to_persist.is_empty() {
             debug!(target: "engine::tree", "Returned empty set of blocks to persist");
-            return
+            return Ok(())
         }
 
         // NOTE: checked non-empty above
@@ -1379,11 +1412,15 @@ where
             .map(|b| b.recovered_block().num_hash())
             .expect("Checked non-empty persisting blocks");
 
+        self.check_persistence_alive()?;
         info!(target: "engine::tree", blocks = ?blocks_to_persist.iter().map(|block| block.recovered_block().num_hash()).collect::<Vec<_>>(), "Persisting blocks");
         let (tx, rx) = oneshot::channel();
-        let _ = self.persistence.save_blocks(blocks_to_persist, tx);
+        self.persistence
+            .save_blocks(blocks_to_persist, tx)
+            .map_err(|_| AdvancePersistenceError::PersistenceServiceDied)?;
 
         self.persistence_state.start_save(highest_num_hash, rx);
+        Ok(())
     }
 
     /// Attempts to advance the persistence state.
@@ -1427,12 +1464,12 @@ where
 
         if !self.persistence_state.in_progress() {
             if let Some(new_tip_num) = self.find_disk_reorg()? {
-                self.remove_blocks(new_tip_num)
+                self.remove_blocks(new_tip_num)?;
             }
 
             if self.should_persist() {
                 let blocks_to_persist = self.get_canonical_blocks_to_persist()?;
-                self.persist_blocks(blocks_to_persist);
+                self.persist_blocks(blocks_to_persist)?;
             }
         }
 
@@ -1877,11 +1914,11 @@ where
     /// height.
     ///
     /// Assumes that `finish` has been called on the `persistence_state` at least once
-    fn on_new_persisted_block(&mut self) -> ProviderResult<()> {
+    fn on_new_persisted_block(&mut self) -> Result<(), AdvancePersistenceError> {
         // If we have an on-disk reorg, we need to handle it first before touching the in-memory
         // state.
         if let Some(remove_above) = self.find_disk_reorg()? {
-            self.remove_blocks(remove_above);
+            self.remove_blocks(remove_above)?;
             return Ok(())
         }
 
@@ -2791,7 +2828,9 @@ where
                 {
                     // we're also persisting the finalized block on disk so we can reload it on
                     // restart this is required by optimism which queries the finalized block: <https://github.com/ethereum-optimism/optimism/blob/c383eb880f307caa3ca41010ec10f30f08396b2e/op-node/rollup/sync/start.go#L65-L65>
-                    let _ = self.persistence.save_finalized_block_number(finalized.number());
+                    if let Err(err) = self.persistence.save_finalized_block_number(finalized.number()) {
+                        error!(target: "engine::tree", %err, "Persistence service died; cannot save finalized block number — node will halt on next persistence cycle");
+                    }
                     self.canonical_in_memory_state.set_finalized(finalized);
                 }
             }
@@ -2819,7 +2858,9 @@ where
                 if Some(safe.num_hash()) != self.canonical_in_memory_state.get_safe_num_hash() {
                     // we're also persisting the safe block on disk so we can reload it on
                     // restart this is required by optimism which queries the safe block: <https://github.com/ethereum-optimism/optimism/blob/c383eb880f307caa3ca41010ec10f30f08396b2e/op-node/rollup/sync/start.go#L65-L65>
-                    let _ = self.persistence.save_safe_block_number(safe.number());
+                    if let Err(err) = self.persistence.save_safe_block_number(safe.number()) {
+                        error!(target: "engine::tree", %err, "Persistence service died; cannot save safe block number — node will halt on next persistence cycle");
+                    }
                     self.canonical_in_memory_state.set_safe(safe);
                 }
             }

--- a/crates/engine/tree/tests/persistence_liveness.rs
+++ b/crates/engine/tree/tests/persistence_liveness.rs
@@ -1,0 +1,317 @@
+//! Tests validating issue #206: PersistenceService death is not detectable by the engine tree.
+//!
+//! ## The bug (three independent facts that combine into the problem)
+//!
+//! **Fact 1** — `spawn_service` (`persistence.rs` lines 416–443) spawns a thread but returns only
+//! `PersistenceHandle`. There is no `watch::Receiver`, `JoinHandle`, or any other liveness signal
+//! in the return value. The caller has no proactive way to know the thread has exited.
+//!
+//! **Fact 2** — When the service thread exits (DB error or panic), the `Receiver` it owns is
+//! dropped. Every subsequent `Sender::send` on the handle returns `Err(SendError)`.
+//!
+//! **Fact 3** — All four call sites in `tree/mod.rs` that drive persistence discard that
+//! `SendError` via `let _ = ...` rather than propagating or handling it:
+//!   - line 1362: `let _ = self.persistence.remove_blocks_above(…)`
+//!   - line 1384: `let _ = self.persistence.save_blocks(…)`
+//!   - line 2794: `let _ = self.persistence.save_finalized_block_number(…)`
+//!   - line 2822: `let _ = self.persistence.save_safe_block_number(…)`
+//!
+//! Together, these three facts mean the node silently stops persisting data with no warning
+//! and no shutdown — it continues accepting blocks and updating in-memory state indefinitely.
+//!
+//! ## What these tests verify
+//!
+//! 1. `spawn_service` is called with real test infrastructure and the return type is exactly
+//!    `PersistenceHandle<EthPrimitives>` — no liveness channel of any kind.
+//!    (Test: [`test_spawn_service_return_type_has_no_liveness_signal`])
+//!
+//! 2. The return-type signature of `spawn_service` in source does not include any watch/channel
+//!    liveness type.
+//!    (Test: [`test_spawn_service_source_signature_has_no_liveness_channel`])
+//!
+//! 3. After the service thread exits (simulated by the same dead-channel state the thread leaves
+//!    behind), `save_finalized_block_number` / `save_safe_block_number` / `save_blocks` /
+//!    `remove_blocks_above` all return `Err(SendError)`.
+//!    (Tests: `test_handle_*_errors_when_service_dead`)
+//!
+//! 4. Source code of `tree/mod.rs` contains `let _ = self.persistence.` at every one of the four
+//!    call sites identified in the issue — confirming the error is structurally discarded.
+//!    (Tests: `test_tree_caller_discards_*`)
+
+use reth_engine_tree::persistence::PersistenceHandle;
+use reth_ethereum_primitives::EthPrimitives;
+use reth_exex_types::FinishedExExHeight;
+use reth_provider::test_utils::create_test_provider_factory;
+use reth_prune::Pruner;
+use tokio::sync::mpsc::unbounded_channel;
+use tokio::sync::oneshot;
+
+// ---------------------------------------------------------------------------
+// Helper: spawn a real PersistenceService via the production path
+// ---------------------------------------------------------------------------
+
+/// Calls the actual `PersistenceHandle::spawn_service` with test-grade infrastructure,
+/// mirroring what the engine tree does at startup.
+fn spawn_test_persistence_service() -> PersistenceHandle<EthPrimitives> {
+    let provider = create_test_provider_factory();
+    let (_finished_exex_height_tx, finished_exex_height_rx) =
+        tokio::sync::watch::channel(FinishedExExHeight::NoExExs);
+    let pruner =
+        Pruner::new_with_factory(provider.clone(), vec![], 5, 0, None, finished_exex_height_rx);
+    let (sync_metrics_tx, _sync_metrics_rx) = unbounded_channel();
+    PersistenceHandle::<EthPrimitives>::spawn_service(provider, pruner, sync_metrics_tx)
+}
+
+/// Returns a `PersistenceHandle` whose backing service has already exited.
+///
+/// This reproduces the exact channel state that exists after the service thread
+/// spawned by `spawn_service` terminates: the `Receiver` end of the mpsc channel is
+/// gone, and the `Sender` (held by the handle) returns `Err(SendError)` on every
+/// subsequent call.
+fn dead_persistence_handle() -> PersistenceHandle<EthPrimitives> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let handle = PersistenceHandle::new(tx);
+    // Dropping `rx` simulates the service thread having exited — identical channel
+    // state to what spawn_service's thread leaves behind on exit.
+    drop(rx);
+    handle
+}
+
+// ---------------------------------------------------------------------------
+// Group 1: Structural — spawn_service provides no liveness signal
+// ---------------------------------------------------------------------------
+
+/// `spawn_service` returns exactly `PersistenceHandle<EthPrimitives>`.
+///
+/// The explicit type annotation is a compile-time assertion: if the function were
+/// fixed to return a liveness signal alongside the handle (e.g., as a tuple
+/// `(PersistenceHandle<…>, watch::Receiver<bool>)`), this test would fail to
+/// compile, confirming the fix.
+///
+/// Currently this compiles and passes, confirming the bug: there is no liveness
+/// channel in the return value of the actual `spawn_service` call.
+#[test]
+fn test_spawn_service_return_type_has_no_liveness_signal() {
+    // EXERCISE spawn_service — the actual function identified in the bug report.
+    let handle: PersistenceHandle<EthPrimitives> = spawn_test_persistence_service();
+
+    // The handle is functional while the service is alive.
+    let result = handle.save_finalized_block_number(0);
+    assert!(
+        result.is_ok(),
+        "handle returned by spawn_service should succeed while the service thread is running"
+    );
+
+    // KEY ASSERTION (structural, via type system):
+    // There is no second return value, no `.liveness_receiver()` method, no
+    // `watch::Receiver`, no `JoinHandle`.  The only way the engine can detect
+    // service death is reactively, by observing `SendError` on the next send —
+    // and every caller in tree/mod.rs discards that error.
+    drop(handle);
+}
+
+/// The source signature of `spawn_service` ends with `-> PersistenceHandle<N::Primitives>`,
+/// not a tuple, and contains no `watch` or liveness type.
+///
+/// This test reads the actual source file so the assertion is tied to the real code,
+/// not a hand-crafted mock. It will fail once the fix adds a liveness channel to
+/// the return type.
+#[test]
+fn test_spawn_service_source_signature_has_no_liveness_channel() {
+    let src = include_str!("../src/persistence.rs");
+
+    // Find the spawn_service function signature block.
+    let sig_start = src
+        .find("pub fn spawn_service<N>")
+        .expect("spawn_service must exist in persistence.rs");
+
+    // Grab enough context to cover the full signature (up to the opening `{`).
+    let sig_region = &src[sig_start..];
+    let body_start = sig_region.find('{').expect("spawn_service must have a body");
+    let signature = &sig_region[..body_start];
+
+    // The return type must be a bare PersistenceHandle — not a tuple, not a watch channel.
+    assert!(
+        signature.contains("-> PersistenceHandle<N::Primitives>"),
+        "spawn_service return type should be PersistenceHandle<N::Primitives>; \
+         currently no liveness channel is returned:\n{signature}"
+    );
+    assert!(
+        !signature.contains("watch::"),
+        "spawn_service must not return a watch channel (liveness signal not yet added):\n\
+         {signature}"
+    );
+    assert!(
+        !signature.contains("JoinHandle"),
+        "spawn_service must not return a JoinHandle (liveness signal not yet added):\n\
+         {signature}"
+    );
+    assert!(
+        !signature.contains('(') || signature.matches('(').count() == 1,
+        "spawn_service return type must not be a tuple (no liveness channel in return):\n\
+         {signature}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Group 2: Behavioral — after service death, sends return errors
+// ---------------------------------------------------------------------------
+
+/// `save_finalized_block_number` returns `Err` once the service thread has exited.
+///
+/// This is what happens on the `handle` returned by `spawn_service` after the
+/// thread from lines 433–440 of `persistence.rs` terminates: the receiver is dropped
+/// and the very same `SendError` is returned — but `update_finalized_block` in
+/// `tree/mod.rs:2794` discards it with `let _ = …`.
+#[test]
+fn test_handle_save_finalized_block_errors_when_service_dead() {
+    let handle = dead_persistence_handle();
+
+    let result = handle.save_finalized_block_number(100);
+
+    assert!(
+        result.is_err(),
+        "save_finalized_block_number must return Err(SendError) when the service thread \
+         has exited (the state left by spawn_service's thread on death); \
+         tree/mod.rs:2794 discards this error with `let _ = …`"
+    );
+}
+
+/// `save_safe_block_number` returns `Err` once the service thread has exited.
+///
+/// `update_safe_block` in `tree/mod.rs:2822` discards this error with `let _ = …`.
+#[test]
+fn test_handle_save_safe_block_errors_when_service_dead() {
+    let handle = dead_persistence_handle();
+
+    let result = handle.save_safe_block_number(100);
+
+    assert!(
+        result.is_err(),
+        "save_safe_block_number must return Err(SendError) when the service thread \
+         has exited; tree/mod.rs:2822 discards this error with `let _ = …`"
+    );
+}
+
+/// `save_blocks` returns `Err` once the service thread has exited.
+///
+/// `persist_blocks` in `tree/mod.rs:1384` discards this error with `let _ = …`.
+/// This is the most consequential failure: blocks are never written to disk, but
+/// the engine updates its in-memory canonical chain as if they were.
+#[test]
+fn test_handle_save_blocks_errors_when_service_dead() {
+    let handle = dead_persistence_handle();
+    let (tx, _rx) = oneshot::channel();
+
+    let result = handle.save_blocks(vec![], tx);
+
+    assert!(
+        result.is_err(),
+        "save_blocks must return Err(SendError) when the service thread has exited; \
+         tree/mod.rs:1384 discards this error with `let _ = …`, causing block data \
+         to be silently lost"
+    );
+}
+
+/// `remove_blocks_above` returns `Err` once the service thread has exited.
+///
+/// `remove_blocks` in `tree/mod.rs:1362` discards this error with `let _ = …`.
+#[test]
+fn test_handle_remove_blocks_above_errors_when_service_dead() {
+    let handle = dead_persistence_handle();
+    let (tx, _rx) = oneshot::channel();
+
+    let result = handle.remove_blocks_above(50, tx);
+
+    assert!(
+        result.is_err(),
+        "remove_blocks_above must return Err(SendError) when the service thread has exited; \
+         tree/mod.rs:1362 discards this error with `let _ = …`"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Group 3: Source inspection — callers in tree/mod.rs discard the errors
+// ---------------------------------------------------------------------------
+//
+// These tests read the actual tree/mod.rs source and assert that each of the
+// four call sites identified in the issue uses `let _ = self.persistence.…`
+// rather than propagating the error.  They pass when the bug is present and
+// will fail once the callers are fixed — providing a precise regression guard.
+
+/// `remove_blocks` at tree/mod.rs:1362 discards the `SendError` from
+/// `remove_blocks_above` via `let _ = …`.
+#[test]
+fn test_tree_caller_discards_remove_blocks_above_error() {
+    let src = include_str!("../src/tree/mod.rs");
+
+    assert!(
+        src.contains("let _ = self.persistence.remove_blocks_above("),
+        "tree/mod.rs must contain `let _ = self.persistence.remove_blocks_above(` \
+         (the `remove_blocks` helper silently discards SendError — issue #206 bug site)"
+    );
+}
+
+/// `persist_blocks` at tree/mod.rs:1384 discards the `SendError` from
+/// `save_blocks` via `let _ = …`.
+#[test]
+fn test_tree_caller_discards_save_blocks_error() {
+    let src = include_str!("../src/tree/mod.rs");
+
+    assert!(
+        src.contains("let _ = self.persistence.save_blocks("),
+        "tree/mod.rs must contain `let _ = self.persistence.save_blocks(` \
+         (the `persist_blocks` helper silently discards SendError — issue #206 bug site)"
+    );
+}
+
+/// `update_finalized_block` at tree/mod.rs:2794 discards the `SendError` from
+/// `save_finalized_block_number` via `let _ = …`.
+#[test]
+fn test_tree_caller_discards_save_finalized_block_error() {
+    let src = include_str!("../src/tree/mod.rs");
+
+    assert!(
+        src.contains("let _ = self.persistence.save_finalized_block_number("),
+        "tree/mod.rs must contain `let _ = self.persistence.save_finalized_block_number(` \
+         (update_finalized_block silently discards SendError — issue #206 bug site)"
+    );
+}
+
+/// `update_safe_block` at tree/mod.rs:2822 discards the `SendError` from
+/// `save_safe_block_number` via `let _ = …`.
+#[test]
+fn test_tree_caller_discards_save_safe_block_error() {
+    let src = include_str!("../src/tree/mod.rs");
+
+    assert!(
+        src.contains("let _ = self.persistence.save_safe_block_number("),
+        "tree/mod.rs must contain `let _ = self.persistence.save_safe_block_number(` \
+         (update_safe_block silently discards SendError — issue #206 bug site)"
+    );
+}
+
+/// All four `let _ = self.persistence.` call sites are present simultaneously.
+///
+/// This consolidated assertion makes it easy to see the full scope of the issue:
+/// every single persistence call made by the engine tree silently discards errors.
+#[test]
+fn test_all_four_tree_persistence_callers_discard_errors() {
+    let src = include_str!("../src/tree/mod.rs");
+
+    let sites = [
+        "let _ = self.persistence.remove_blocks_above(",
+        "let _ = self.persistence.save_blocks(",
+        "let _ = self.persistence.save_finalized_block_number(",
+        "let _ = self.persistence.save_safe_block_number(",
+    ];
+
+    for site in &sites {
+        assert!(
+            src.contains(site),
+            "Expected `{site}` in tree/mod.rs — this is one of the four call sites \
+             (issue #206) where SendError is silently discarded with `let _ = …`. \
+             If this assertion fails, the corresponding caller has been fixed."
+        );
+    }
+}

--- a/crates/engine/tree/tests/persistence_liveness.rs
+++ b/crates/engine/tree/tests/persistence_liveness.rs
@@ -1,42 +1,45 @@
-//! Tests validating issue #206: PersistenceService death is not detectable by the engine tree.
+//! Tests validating the fix for issue #206: PersistenceService death must be detectable by the
+//! engine tree so that data loss is prevented.
 //!
-//! ## The bug (three independent facts that combine into the problem)
+//! ## The bug (three independent facts that combined into the problem)
 //!
-//! **Fact 1** — `spawn_service` (`persistence.rs` lines 416–443) spawns a thread but returns only
-//! `PersistenceHandle`. There is no `watch::Receiver`, `JoinHandle`, or any other liveness signal
-//! in the return value. The caller has no proactive way to know the thread has exited.
+//! **Fact 1** — `spawn_service` spawned a thread but returned only `PersistenceHandle`. There was
+//! no `watch::Receiver`, `JoinHandle`, or any other liveness signal in the return value.
 //!
-//! **Fact 2** — When the service thread exits (DB error or panic), the `Receiver` it owns is
-//! dropped. Every subsequent `Sender::send` on the handle returns `Err(SendError)`.
+//! **Fact 2** — When the service thread exited (DB error or panic), the `Receiver` it owned was
+//! dropped. Every subsequent `Sender::send` on the handle returned `Err(SendError)`.
 //!
-//! **Fact 3** — All four call sites in `tree/mod.rs` that drive persistence discard that
-//! `SendError` via `let _ = ...` rather than propagating or handling it:
-//!   - line 1362: `let _ = self.persistence.remove_blocks_above(…)`
-//!   - line 1384: `let _ = self.persistence.save_blocks(…)`
-//!   - line 2794: `let _ = self.persistence.save_finalized_block_number(…)`
-//!   - line 2822: `let _ = self.persistence.save_safe_block_number(…)`
+//! **Fact 3** — All four call sites in `tree/mod.rs` that drove persistence discarded that
+//! `SendError` via `let _ = ...` rather than propagating or handling it.
 //!
-//! Together, these three facts mean the node silently stops persisting data with no warning
-//! and no shutdown — it continues accepting blocks and updating in-memory state indefinitely.
+//! Together, these three facts meant the node silently stopped persisting data with no warning
+//! and no shutdown.
+//!
+//! ## The fix
+//!
+//! `spawn_service` now returns `(PersistenceHandle, watch::Receiver<bool>)`. The receiver holds
+//! `true` while the service is running and transitions to `false` when the service exits. The
+//! engine tree stores the receiver and checks it before each persistence dispatch, returning a
+//! fatal `AdvancePersistenceError::PersistenceServiceDied` that stops the engine loop.
 //!
 //! ## What these tests verify
 //!
-//! 1. `spawn_service` is called with real test infrastructure and the return type is exactly
-//!    `PersistenceHandle<EthPrimitives>` — no liveness channel of any kind.
-//!    (Test: [`test_spawn_service_return_type_has_no_liveness_signal`])
+//! 1. `spawn_service` returns a tuple `(PersistenceHandle, watch::Receiver<bool>)` with a
+//!    liveness signal.
+//!    (Test: [`test_spawn_service_return_type_has_liveness_signal`])
 //!
-//! 2. The return-type signature of `spawn_service` in source does not include any watch/channel
-//!    liveness type.
-//!    (Test: [`test_spawn_service_source_signature_has_no_liveness_channel`])
+//! 2. The liveness receiver reports `true` while the service is alive and transitions to `false`
+//!    after the service exits.
+//!    (Test: [`test_liveness_receiver_transitions_to_false_on_service_death`])
 //!
 //! 3. After the service thread exits (simulated by the same dead-channel state the thread leaves
 //!    behind), `save_finalized_block_number` / `save_safe_block_number` / `save_blocks` /
 //!    `remove_blocks_above` all return `Err(SendError)`.
 //!    (Tests: `test_handle_*_errors_when_service_dead`)
 //!
-//! 4. Source code of `tree/mod.rs` contains `let _ = self.persistence.` at every one of the four
-//!    call sites identified in the issue — confirming the error is structurally discarded.
-//!    (Tests: `test_tree_caller_discards_*`)
+//! 4. Source code of `tree/mod.rs` no longer contains `let _ = self.persistence.` at the four
+//!    call sites — confirming the errors are no longer silently discarded.
+//!    (Tests: `test_tree_caller_propagates_*`)
 
 use reth_engine_tree::persistence::PersistenceHandle;
 use reth_ethereum_primitives::EthPrimitives;
@@ -52,7 +55,7 @@ use tokio::sync::oneshot;
 
 /// Calls the actual `PersistenceHandle::spawn_service` with test-grade infrastructure,
 /// mirroring what the engine tree does at startup.
-fn spawn_test_persistence_service() -> PersistenceHandle<EthPrimitives> {
+fn spawn_test_persistence_service() -> (PersistenceHandle<EthPrimitives>, tokio::sync::watch::Receiver<bool>) {
     let provider = create_test_provider_factory();
     let (_finished_exex_height_tx, finished_exex_height_rx) =
         tokio::sync::watch::channel(FinishedExExHeight::NoExExs);
@@ -78,22 +81,17 @@ fn dead_persistence_handle() -> PersistenceHandle<EthPrimitives> {
 }
 
 // ---------------------------------------------------------------------------
-// Group 1: Structural — spawn_service provides no liveness signal
+// Group 1: Structural — spawn_service provides a liveness signal (fix verified)
 // ---------------------------------------------------------------------------
 
-/// `spawn_service` returns exactly `PersistenceHandle<EthPrimitives>`.
+/// `spawn_service` now returns `(PersistenceHandle<EthPrimitives>, watch::Receiver<bool>)`.
 ///
-/// The explicit type annotation is a compile-time assertion: if the function were
-/// fixed to return a liveness signal alongside the handle (e.g., as a tuple
-/// `(PersistenceHandle<…>, watch::Receiver<bool>)`), this test would fail to
-/// compile, confirming the fix.
-///
-/// Currently this compiles and passes, confirming the bug: there is no liveness
-/// channel in the return value of the actual `spawn_service` call.
+/// This test confirms the fix: the return value includes a liveness receiver that allows
+/// the engine to detect when the persistence service has died.
 #[test]
-fn test_spawn_service_return_type_has_no_liveness_signal() {
+fn test_spawn_service_return_type_has_liveness_signal() {
     // EXERCISE spawn_service — the actual function identified in the bug report.
-    let handle: PersistenceHandle<EthPrimitives> = spawn_test_persistence_service();
+    let (handle, mut liveness_rx) = spawn_test_persistence_service();
 
     // The handle is functional while the service is alive.
     let result = handle.save_finalized_block_number(0);
@@ -102,67 +100,70 @@ fn test_spawn_service_return_type_has_no_liveness_signal() {
         "handle returned by spawn_service should succeed while the service thread is running"
     );
 
-    // KEY ASSERTION (structural, via type system):
-    // There is no second return value, no `.liveness_receiver()` method, no
-    // `watch::Receiver`, no `JoinHandle`.  The only way the engine can detect
-    // service death is reactively, by observing `SendError` on the next send —
-    // and every caller in tree/mod.rs discards that error.
+    // KEY ASSERTION: liveness receiver reports `true` while the service is alive.
+    assert!(
+        *liveness_rx.borrow_and_update(),
+        "liveness receiver must report true while the persistence service is running"
+    );
+
     drop(handle);
 }
 
-/// The source signature of `spawn_service` ends with `-> PersistenceHandle<N::Primitives>`,
-/// not a tuple, and contains no `watch` or liveness type.
+/// The liveness receiver transitions to `false` when the service exits.
 ///
-/// This test reads the actual source file so the assertion is tied to the real code,
-/// not a hand-crafted mock. It will fail once the fix adds a liveness channel to
-/// the return type.
+/// This test verifies the core detection mechanism: after the persistence thread exits,
+/// the engine can observe `false` on the liveness receiver and stop with a controlled shutdown.
+#[tokio::test]
+async fn test_liveness_receiver_transitions_to_false_on_service_death() {
+    let (tx, rx) = std::sync::mpsc::channel::<reth_engine_tree::persistence::PersistenceAction<EthPrimitives>>();
+    let (liveness_tx, liveness_rx) = tokio::sync::watch::channel(true);
+
+    // Simulate the persistence thread: hold a reference, then exit and signal death.
+    let thread = std::thread::spawn(move || {
+        drop(rx); // service thread "exits"
+        let _ = liveness_tx.send(false); // signal death
+    });
+    thread.join().unwrap();
+
+    drop(tx);
+
+    // The liveness receiver must now report `false`.
+    assert!(
+        !*liveness_rx.borrow(),
+        "liveness receiver must transition to false after the persistence service thread exits"
+    );
+}
+
+/// The source signature of `spawn_service` includes a watch liveness channel in the return type.
+///
+/// This test reads the actual source file so the assertion is tied to the real code.
 #[test]
-fn test_spawn_service_source_signature_has_no_liveness_channel() {
+fn test_spawn_service_source_signature_has_liveness_channel() {
     let src = include_str!("../src/persistence.rs");
 
-    // Find the spawn_service function signature block.
     let sig_start = src
         .find("pub fn spawn_service<N>")
         .expect("spawn_service must exist in persistence.rs");
 
-    // Grab enough context to cover the full signature (up to the opening `{`).
     let sig_region = &src[sig_start..];
     let body_start = sig_region.find('{').expect("spawn_service must have a body");
     let signature = &sig_region[..body_start];
 
-    // The return type must be a bare PersistenceHandle — not a tuple, not a watch channel.
     assert!(
-        signature.contains("-> PersistenceHandle<N::Primitives>"),
-        "spawn_service return type should be PersistenceHandle<N::Primitives>; \
-         currently no liveness channel is returned:\n{signature}"
+        signature.contains("watch::Receiver<bool>"),
+        "spawn_service must return a watch::Receiver<bool> liveness signal (fix for #206):\n{signature}"
     );
     assert!(
-        !signature.contains("watch::"),
-        "spawn_service must not return a watch channel (liveness signal not yet added):\n\
-         {signature}"
-    );
-    assert!(
-        !signature.contains("JoinHandle"),
-        "spawn_service must not return a JoinHandle (liveness signal not yet added):\n\
-         {signature}"
-    );
-    assert!(
-        !signature.contains('(') || signature.matches('(').count() == 1,
-        "spawn_service return type must not be a tuple (no liveness channel in return):\n\
-         {signature}"
+        signature.contains("PersistenceHandle"),
+        "spawn_service must still return a PersistenceHandle:\n{signature}"
     );
 }
 
 // ---------------------------------------------------------------------------
-// Group 2: Behavioral — after service death, sends return errors
+// Group 2: Behavioral — after service death, sends return errors (unchanged)
 // ---------------------------------------------------------------------------
 
 /// `save_finalized_block_number` returns `Err` once the service thread has exited.
-///
-/// This is what happens on the `handle` returned by `spawn_service` after the
-/// thread from lines 433–440 of `persistence.rs` terminates: the receiver is dropped
-/// and the very same `SendError` is returned — but `update_finalized_block` in
-/// `tree/mod.rs:2794` discards it with `let _ = …`.
 #[test]
 fn test_handle_save_finalized_block_errors_when_service_dead() {
     let handle = dead_persistence_handle();
@@ -171,15 +172,11 @@ fn test_handle_save_finalized_block_errors_when_service_dead() {
 
     assert!(
         result.is_err(),
-        "save_finalized_block_number must return Err(SendError) when the service thread \
-         has exited (the state left by spawn_service's thread on death); \
-         tree/mod.rs:2794 discards this error with `let _ = …`"
+        "save_finalized_block_number must return Err(SendError) when the service thread has exited"
     );
 }
 
 /// `save_safe_block_number` returns `Err` once the service thread has exited.
-///
-/// `update_safe_block` in `tree/mod.rs:2822` discards this error with `let _ = …`.
 #[test]
 fn test_handle_save_safe_block_errors_when_service_dead() {
     let handle = dead_persistence_handle();
@@ -188,16 +185,11 @@ fn test_handle_save_safe_block_errors_when_service_dead() {
 
     assert!(
         result.is_err(),
-        "save_safe_block_number must return Err(SendError) when the service thread \
-         has exited; tree/mod.rs:2822 discards this error with `let _ = …`"
+        "save_safe_block_number must return Err(SendError) when the service thread has exited"
     );
 }
 
 /// `save_blocks` returns `Err` once the service thread has exited.
-///
-/// `persist_blocks` in `tree/mod.rs:1384` discards this error with `let _ = …`.
-/// This is the most consequential failure: blocks are never written to disk, but
-/// the engine updates its in-memory canonical chain as if they were.
 #[test]
 fn test_handle_save_blocks_errors_when_service_dead() {
     let handle = dead_persistence_handle();
@@ -207,15 +199,11 @@ fn test_handle_save_blocks_errors_when_service_dead() {
 
     assert!(
         result.is_err(),
-        "save_blocks must return Err(SendError) when the service thread has exited; \
-         tree/mod.rs:1384 discards this error with `let _ = …`, causing block data \
-         to be silently lost"
+        "save_blocks must return Err(SendError) when the service thread has exited"
     );
 }
 
 /// `remove_blocks_above` returns `Err` once the service thread has exited.
-///
-/// `remove_blocks` in `tree/mod.rs:1362` discards this error with `let _ = …`.
 #[test]
 fn test_handle_remove_blocks_above_errors_when_service_dead() {
     let handle = dead_persistence_handle();
@@ -225,93 +213,85 @@ fn test_handle_remove_blocks_above_errors_when_service_dead() {
 
     assert!(
         result.is_err(),
-        "remove_blocks_above must return Err(SendError) when the service thread has exited; \
-         tree/mod.rs:1362 discards this error with `let _ = …`"
+        "remove_blocks_above must return Err(SendError) when the service thread has exited"
     );
 }
 
 // ---------------------------------------------------------------------------
-// Group 3: Source inspection — callers in tree/mod.rs discard the errors
+// Group 3: Source inspection — callers in tree/mod.rs no longer discard errors
 // ---------------------------------------------------------------------------
 //
 // These tests read the actual tree/mod.rs source and assert that each of the
-// four call sites identified in the issue uses `let _ = self.persistence.…`
-// rather than propagating the error.  They pass when the bug is present and
-// will fail once the callers are fixed — providing a precise regression guard.
+// four call sites identified in the issue NO LONGER uses `let _ = self.persistence.…`.
+// They pass when the fix is applied and serve as regression guards against re-introducing
+// the silent discard pattern.
 
-/// `remove_blocks` at tree/mod.rs:1362 discards the `SendError` from
-/// `remove_blocks_above` via `let _ = …`.
+/// `remove_blocks` no longer discards the error from `remove_blocks_above`.
 #[test]
-fn test_tree_caller_discards_remove_blocks_above_error() {
+fn test_tree_caller_propagates_remove_blocks_above_error() {
     let src = include_str!("../src/tree/mod.rs");
 
     assert!(
-        src.contains("let _ = self.persistence.remove_blocks_above("),
-        "tree/mod.rs must contain `let _ = self.persistence.remove_blocks_above(` \
-         (the `remove_blocks` helper silently discards SendError — issue #206 bug site)"
+        !src.contains("let _ = self.persistence.remove_blocks_above("),
+        "tree/mod.rs must NOT contain `let _ = self.persistence.remove_blocks_above(` \
+         after the fix for issue #206 — errors from persistence must be propagated"
     );
 }
 
-/// `persist_blocks` at tree/mod.rs:1384 discards the `SendError` from
-/// `save_blocks` via `let _ = …`.
+/// `persist_blocks` no longer discards the error from `save_blocks`.
 #[test]
-fn test_tree_caller_discards_save_blocks_error() {
+fn test_tree_caller_propagates_save_blocks_error() {
     let src = include_str!("../src/tree/mod.rs");
 
     assert!(
-        src.contains("let _ = self.persistence.save_blocks("),
-        "tree/mod.rs must contain `let _ = self.persistence.save_blocks(` \
-         (the `persist_blocks` helper silently discards SendError — issue #206 bug site)"
+        !src.contains("let _ = self.persistence.save_blocks("),
+        "tree/mod.rs must NOT contain `let _ = self.persistence.save_blocks(` \
+         after the fix for issue #206 — errors from persistence must be propagated"
     );
 }
 
-/// `update_finalized_block` at tree/mod.rs:2794 discards the `SendError` from
-/// `save_finalized_block_number` via `let _ = …`.
+/// `update_finalized_block` no longer silently discards the error from `save_finalized_block_number`.
 #[test]
-fn test_tree_caller_discards_save_finalized_block_error() {
+fn test_tree_caller_propagates_save_finalized_block_error() {
     let src = include_str!("../src/tree/mod.rs");
 
     assert!(
-        src.contains("let _ = self.persistence.save_finalized_block_number("),
-        "tree/mod.rs must contain `let _ = self.persistence.save_finalized_block_number(` \
-         (update_finalized_block silently discards SendError — issue #206 bug site)"
+        !src.contains("let _ = self.persistence.save_finalized_block_number("),
+        "tree/mod.rs must NOT contain `let _ = self.persistence.save_finalized_block_number(` \
+         after the fix for issue #206"
     );
 }
 
-/// `update_safe_block` at tree/mod.rs:2822 discards the `SendError` from
-/// `save_safe_block_number` via `let _ = …`.
+/// `update_safe_block` no longer silently discards the error from `save_safe_block_number`.
 #[test]
-fn test_tree_caller_discards_save_safe_block_error() {
+fn test_tree_caller_propagates_save_safe_block_error() {
     let src = include_str!("../src/tree/mod.rs");
 
     assert!(
-        src.contains("let _ = self.persistence.save_safe_block_number("),
-        "tree/mod.rs must contain `let _ = self.persistence.save_safe_block_number(` \
-         (update_safe_block silently discards SendError — issue #206 bug site)"
+        !src.contains("let _ = self.persistence.save_safe_block_number("),
+        "tree/mod.rs must NOT contain `let _ = self.persistence.save_safe_block_number(` \
+         after the fix for issue #206"
     );
 }
 
-/// All four `let _ = self.persistence.` call sites are present simultaneously.
-///
-/// This consolidated assertion makes it easy to see the full scope of the issue:
-/// every single persistence call made by the engine tree silently discards errors.
+/// None of the four previously-identified `let _ = self.persistence.` call sites remain.
 #[test]
-fn test_all_four_tree_persistence_callers_discard_errors() {
+fn test_no_persistence_errors_silently_discarded() {
     let src = include_str!("../src/tree/mod.rs");
 
-    let sites = [
+    let silent_sites = [
         "let _ = self.persistence.remove_blocks_above(",
         "let _ = self.persistence.save_blocks(",
         "let _ = self.persistence.save_finalized_block_number(",
         "let _ = self.persistence.save_safe_block_number(",
     ];
 
-    for site in &sites {
+    for site in &silent_sites {
         assert!(
-            src.contains(site),
-            "Expected `{site}` in tree/mod.rs — this is one of the four call sites \
-             (issue #206) where SendError is silently discarded with `let _ = …`. \
-             If this assertion fails, the corresponding caller has been fixed."
+            !src.contains(site),
+            "Found `{site}` in tree/mod.rs — this is one of the four call sites \
+             (issue #206) where SendError must no longer be silently discarded with `let _ = …`. \
+             The fix requires propagating or at minimum logging these errors."
         );
     }
 }


### PR DESCRIPTION
Closes #206

Good — the two `test_save_blocks_multiple_*` failures are pre-existing and unrelated to this fix. All 12 new tests pass. Here's a summary of the changes:

---

## Summary

**Root cause**: `spawn_service` returned only `PersistenceHandle` with no liveness signal. When the persistence thread died, all sends returned `SendError` but every call site used `let _ =` to silently discard it.

### Changes made

**`crates/engine/tree/src/persistence.rs`**
- Changed `spawn_service` return type from `PersistenceHandle<N::Primitives>` to `(PersistenceHandle<N::Primitives>, watch::Receiver<bool>)`
- Created a `watch::channel(true)` inside `spawn_service`; the thread closure now holds the sender and sends `false` before exiting, signalling service death
- Updated internal test helper to unwrap `.0` from the tuple

**`crates/engine/tree/src/tree/error.rs`**
- Added `PersistenceServiceDied` variant to `AdvancePersistenceError`

**`crates/engine/tree/src/tree/mod.rs`**
- Added `persistence_liveness: Opt

Automated fix by Coacker.